### PR TITLE
Add more complex RPM version handling.

### DIFF
--- a/RPM/Version.hs
+++ b/RPM/Version.hs
@@ -15,10 +15,48 @@
 
 {-# LANGUAGE MultiWayIf #-}
 
-module RPM.Version(vercmp)
+module RPM.Version(DepOrdering(..),
+                   DepRequirement(..),
+                   EVR(..),
+                   parseEVR,
+                   parseDepRequirement,
+                   satisfies,
+                   vercmp)
  where
 
-import Data.Char(isAsciiLower, isAsciiUpper, isDigit)
+import           Data.Char(digitToInt, isAsciiLower, isAsciiUpper, isDigit, isSpace)
+import           Data.Maybe(fromMaybe)
+import           Data.Monoid((<>))
+import qualified Data.Ord as Ord
+import           Data.Word(Word32)
+import           Text.Parsec
+
+import Prelude hiding(EQ, GT, LT)
+
+-- optional epoch, version, release
+data EVR = EVR {
+    epoch :: Maybe Word32,
+    version :: String,
+    release :: String }
+ deriving(Show)
+
+-- for Ord and Eq, an epoch of Nothing is the same as an epoch of 0.
+-- for Eq, version and release strings need to go through vercmp, since they can be equivalent
+-- without being the same String.
+instance Eq EVR where
+    (==) evr1 evr2 = evr1 `compare` evr2 == Ord.EQ
+
+instance Ord EVR where
+    compare evr1 evr2 = fromMaybe 0 (epoch evr1) `compare` fromMaybe 0 (epoch evr2) <>
+                        version evr1 `vercmp` version evr2 <>
+                        release evr1 `vercmp` release evr2
+
+-- Like Ordering, but with >= and <=
+data DepOrdering = LT | LTE | EQ | GTE | GT
+ deriving(Eq, Show)
+
+data DepRequirement = DepRequirement String (Maybe (DepOrdering, EVR))
+ deriving (Eq, Show)
 
 vercmp :: String -> String -> Ordering
 vercmp a b = let
@@ -29,14 +67,14 @@ vercmp a b = let
   in
     case (a', b') of
         -- Nothing left means the versions are equal
-        ([], [])   -> EQ
+        ([], [])   -> Ord.EQ
         -- tilde ls less than everything, including an empty string
         ('~':aTail, '~':bTail) -> vercmp aTail bTail
-        ('~':_, _) -> LT
-        (_, '~':_) -> GT
+        ('~':_, _) -> Ord.LT
+        (_, '~':_) -> Ord.GT
         -- otherwise, if one of the strings is null, the other is greater
-        ([], _)    -> LT
-        (_, [])    -> GT
+        ([], _)    -> Ord.LT
+        (_, [])    -> Ord.GT
         -- Now we have two non-null strings, starting with a non-tilde version character
         _          -> let 
             -- rpm compares strings by digit and non-digit components, so grab the first
@@ -47,8 +85,8 @@ vercmp a b = let
          in
             -- if one prefix is a number and the other is a string, the one
             -- that is a number is the more recent version number
-            if | isDigit (head a') && (not . isDigit) (head b') -> GT
-               | (not . isDigit) (head a') && isDigit (head b') -> LT
+            if | isDigit (head a') && (not . isDigit) (head b') -> Ord.GT
+               | (not . isDigit) (head a') && isDigit (head b') -> Ord.LT
                | isDigit (head a') -> (prefixA `compareAsInts` prefixB) `mappend` (suffixA `vercmp` suffixB)
                | otherwise -> (prefixA `compare` prefixB) `mappend` (suffixA `vercmp` suffixB)
   where
@@ -59,7 +97,7 @@ vercmp a b = let
         let x' = dropWhile (== '0') x
             y' = dropWhile (== '0') y
         in 
-            if length x' > length y' then GT
+            if length x' > length y' then Ord.GT
             else x' `compare` y'
 
     -- isAlpha returns any unicode alpha, but we just want ASCII characters
@@ -72,3 +110,119 @@ vercmp a b = let
 
     dropSeparators :: String -> String
     dropSeparators = dropWhile (not . isVersionChar)
+
+{-# ANN satisfies "HLint: ignore Redundant if" #-}
+satisfies :: DepRequirement -> DepRequirement -> Bool
+satisfies (DepRequirement name1 ver1) (DepRequirement name2 ver2) =
+    -- names have to match
+    if name1 /= name2 then False
+    else satisfiesVersion ver1 ver2
+ where
+    -- If either half has no version expression, it's a match
+    satisfiesVersion Nothing _ = True
+    satisfiesVersion _ Nothing = True
+
+    -- There is a special case for matching versions with no release component.
+    -- If one side is equal to (or >=, or <=) a version with no release component, it will match any non-empty
+    -- release on the other side, regardless of operator.
+    -- For example: x >= 1.0 `satisfies` x < 1.0-47.
+    -- If *both* sides have no release, the regular rules apply, so x >= 1.0 does not satisfy x < 1.0
+
+    satisfiesVersion (Just (o1, v1)) (Just (o2, v2))
+        | null (release v1) && (not . null) (release v2) && compareEV v1 v2 && isEq o1 = True
+        | null (release v2) && (not . null) (release v1) && compareEV v1 v2 && isEq o2 = True
+        | otherwise =
+            case compare v1 v2 of
+                -- e1 < e2, true if >[=] e1 || <[=] e2
+                Ord.LT -> isGt o1 || isLt o2
+                -- e1 > e2, true if <[=] e1 || >[=] e2
+                Ord.GT -> isLt o1 || isGt o2
+                -- e1 == e2, true if both sides are the same direction
+                Ord.EQ -> (isLt o1 && isLt o2) || (isEq o1 && isEq o2) || (isGt o1 && isGt o2)
+
+    isEq EQ  = True
+    isEq GTE = True
+    isEq LTE = True
+    isEq _   = False
+
+    isLt LT  = True
+    isLt LTE = True
+    isLt _   = False
+
+    isGt GT  = True
+    isGt GTE = True
+    isGt _   = False
+
+    compareEV v1 v2 = fromMaybe 0 (epoch v1) == fromMaybe 0 (epoch v2) && version v1 == version v2
+
+-- parsers for version strings
+-- the EVR Parsec is shared by the EVR and DepRequirement parsers
+parseEVRParsec :: Parsec String () EVR
+parseEVRParsec = do
+    e <- optionMaybe $ try parseEpoch
+    v <- many1 versionChar
+    r <- try parseRelease <|> return ""
+    eof
+
+    return EVR{epoch=e, version=v, release=r}
+ where
+    parseEpoch :: Parsec String () Word32
+    parseEpoch = do
+        e <- many1 digit
+        _ <- char ':'
+
+        -- parse the digit string as an Integer until it ends or overflows Word32
+        parseInteger 0 e
+     where
+        maxW32 = toInteger (maxBound :: Word32)
+
+        parseInteger :: Integer -> String -> Parsec String () Word32
+        parseInteger acc []     = return $ fromInteger acc
+        parseInteger acc (x:xs) = let
+            newAcc = (acc * (10 :: Integer)) + toInteger (digitToInt x)
+         in
+            if newAcc > maxW32 then parserFail ""
+            else parseInteger newAcc xs
+
+    parseRelease = do
+        _ <- char '-'
+        many1 versionChar
+
+    versionChar = digit <|> upper <|> lower <|> oneOf "._+%{}~"
+
+parseEVR :: String -> Either ParseError EVR
+parseEVR = parse parseEVRParsec ""
+
+parseDepRequirement :: String -> Either ParseError DepRequirement
+parseDepRequirement input = parse parseDepRequirement' "" input
+ where
+    parseDepRequirement' = do
+        reqname <- many $ satisfy (not . isSpace)
+        spaces
+        reqver <- optionMaybe $ try parseDepVersion
+
+        -- If anything went wrong in parsing the version (invalid operator, malformed EVR), treat the entire
+        -- string as a name. This way RPMs with bad version strings in Requires, which of course exist, will
+        -- match against the full string.
+        case reqver of
+            Just _  -> return $ DepRequirement reqname reqver
+            Nothing -> return $ DepRequirement input Nothing
+
+    -- check lte and gte first, since they overlap lt and gt
+    parseOperator :: Parsec String () DepOrdering
+    parseOperator = lte <|> gte <|> eq <|> lt <|> gt
+
+    eq  = try (string "=")  >> return EQ
+    lt  = try (string "<")  >> return LT
+    gt  = try (string ">")  >> return GT
+    lte = try (string "<=") >> return LTE
+    gte = try (string ">=") >> return GTE
+
+    parseDepVersion :: Parsec String () (DepOrdering, EVR)
+    parseDepVersion = do
+        oper <- parseOperator
+        spaces
+        evr <- parseEVRParsec
+        eof
+
+        return (oper, evr)

--- a/rpm.cabal
+++ b/rpm.cabal
@@ -23,6 +23,7 @@ library
                         conduit-combinators,
                         conduit-extra,
                         mtl >= 2.2.1,
+                        parsec,
                         pretty >= 1.1.2.0,
                         resourcet
 

--- a/rpm.cabal
+++ b/rpm.cabal
@@ -25,7 +25,8 @@ library
                         mtl >= 2.2.1,
                         parsec,
                         pretty >= 1.1.2.0,
-                        resourcet
+                        resourcet,
+                        text
 
     default-language:   Haskell2010
 
@@ -105,7 +106,8 @@ test-suite tests
     build-depends:      HUnit,
                         hspec,
                         base >= 4.7 && < 5.0,
-                        rpm
+                        rpm,
+                        text
 
     default-language:   Haskell2010
 

--- a/tests/RPM/VersionSpec.hs
+++ b/tests/RPM/VersionSpec.hs
@@ -2,102 +2,351 @@ module RPM.VersionSpec (main, spec) where
 
 import Test.Hspec
 import Data.Foldable(forM_)
-import RPM.Version(vercmp)
+import RPM.Version(DepRequirement(..), EVR(..), parseDepRequirement, parseEVR, satisfies, vercmp)
+import qualified RPM.Version as RPM(DepOrdering(..))
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec = describe "RPM.Version.vercmp" $ do
-    let versionCases = [
-                     ("1.0", "1.0", EQ),
-                     ("1.0", "2.0", LT),
-                     ("2.0", "1.0", GT),
+spec = do
+    describe "RPM.Version.vercmp" $ do
+        let vercmpCases = [
+                         ("1.0", "1.0", EQ),
+                         ("1.0", "2.0", LT),
+                         ("2.0", "1.0", GT),
 
-                     ("2.0.1", "2.0.1", EQ),
-                     ("2.0", "2.0.1", LT),
-                     ("2.0.1", "2.0", GT),
+                         ("2.0.1", "2.0.1", EQ),
+                         ("2.0", "2.0.1", LT),
+                         ("2.0.1", "2.0", GT),
 
-                     ("2.0.1a", "2.0.1a", EQ),
-                     ("2.0.1a", "2.0.1", GT),
-                     ("2.0.1", "2.0.1a", LT),
+                         ("2.0.1a", "2.0.1a", EQ),
+                         ("2.0.1a", "2.0.1", GT),
+                         ("2.0.1", "2.0.1a", LT),
 
-                     ("5.5p1", "5.5p1", EQ),
-                     ("5.5p1", "5.5p2", LT),
-                     ("5.5p2", "5.5p1", GT),
+                         ("5.5p1", "5.5p1", EQ),
+                         ("5.5p1", "5.5p2", LT),
+                         ("5.5p2", "5.5p1", GT),
 
-                     ("5.5p10", "5.5p10", EQ),
-                     ("5.5p1", "5.5p10", LT),
-                     ("5.5p10", "5.5p1", GT),
+                         ("5.5p10", "5.5p10", EQ),
+                         ("5.5p1", "5.5p10", LT),
+                         ("5.5p10", "5.5p1", GT),
 
-                     ("10xyz", "10.1xyz", LT),
-                     ("10.1xyz", "10xyz", GT),
+                         ("10xyz", "10.1xyz", LT),
+                         ("10.1xyz", "10xyz", GT),
 
-                     ("xyz10", "xyz10", EQ),
-                     ("xyz10", "xyz10.1", LT),
-                     ("xyz10.1", "xyz10", GT),
+                         ("xyz10", "xyz10", EQ),
+                         ("xyz10", "xyz10.1", LT),
+                         ("xyz10.1", "xyz10", GT),
 
-                     ("xyz.4", "xyz.4", EQ),
-                     ("xyz.4", "8", LT),
-                     ("8", "xyz.4", GT),
-                     ("xyz.4", "2", LT),
-                     ("2", "xyz.4", GT),
+                         ("xyz.4", "xyz.4", EQ),
+                         ("xyz.4", "8", LT),
+                         ("8", "xyz.4", GT),
+                         ("xyz.4", "2", LT),
+                         ("2", "xyz.4", GT),
 
-                     ("5.5p2", "5.6p1", LT),
-                     ("5.6p1", "5.5p2", GT),
+                         ("5.5p2", "5.6p1", LT),
+                         ("5.6p1", "5.5p2", GT),
 
-                     ("5.6p1", "6.5p1", LT),
-                     ("6.5p1", "5.6p1", GT),
+                         ("5.6p1", "6.5p1", LT),
+                         ("6.5p1", "5.6p1", GT),
 
-                     ("6.0.rc1", "6.0", GT),
-                     ("6.0", "6.0.rc1", LT),
+                         ("6.0.rc1", "6.0", GT),
+                         ("6.0", "6.0.rc1", LT),
 
-                     ("10b2", "10a1", GT),
-                     ("10a2", "10b2", LT),
-                     ("1.0aa", "1.0aa", EQ),
-                     ("1.0a", "1.0aa", LT),
-                     ("1.0aa", "1.0a", GT),
+                         ("10b2", "10a1", GT),
+                         ("10a2", "10b2", LT),
+                         ("1.0aa", "1.0aa", EQ),
+                         ("1.0a", "1.0aa", LT),
+                         ("1.0aa", "1.0a", GT),
 
-                     ("10.0001", "10.0001", EQ),
-                     ("10.0001", "10.1", EQ),
-                     ("10.1", "10.0001", EQ),
-                     ("10.0001", "10.0039", LT),
-                     ("10.0039", "10.0001", GT),
+                         ("10.0001", "10.0001", EQ),
+                         ("10.0001", "10.1", EQ),
+                         ("10.1", "10.0001", EQ),
+                         ("10.0001", "10.0039", LT),
+                         ("10.0039", "10.0001", GT),
 
-                     ("4.999.9", "5.0", LT),
-                     ("5.0", "4.999.9", GT),
+                         ("4.999.9", "5.0", LT),
+                         ("5.0", "4.999.9", GT),
 
-                     ("20101121", "20101121", EQ),
-                     ("20101121", "20101122", LT),
-                     ("20101122", "20101121", GT),
+                         ("20101121", "20101121", EQ),
+                         ("20101121", "20101122", LT),
+                         ("20101122", "20101121", GT),
 
-                     ("2_0", "2_0", EQ),
-                     ("2.0", "2_0", EQ),
-                     ("2_0", "2.0", EQ),
+                         ("2_0", "2_0", EQ),
+                         ("2.0", "2_0", EQ),
+                         ("2_0", "2.0", EQ),
 
-                     ("a", "a", EQ),
-                     ("a+", "a+", EQ),
-                     ("a+", "a_", EQ),
-                     ("a_", "a+", EQ),
-                     ("+a", "+a", EQ),
-                     ("+a", "_a", EQ),
-                     ("_a", "+a", EQ),
-                     ("+_", "+_", EQ),
-                     ("_+", "+_", EQ),
-                     ("_+", "_+", EQ),
-                     ("+", "_", EQ),
-                     ("_", "+", EQ),
+                         ("a", "a", EQ),
+                         ("a+", "a+", EQ),
+                         ("a+", "a_", EQ),
+                         ("a_", "a+", EQ),
+                         ("+a", "+a", EQ),
+                         ("+a", "_a", EQ),
+                         ("_a", "+a", EQ),
+                         ("+_", "+_", EQ),
+                         ("_+", "+_", EQ),
+                         ("_+", "_+", EQ),
+                         ("+", "_", EQ),
+                         ("_", "+", EQ),
 
-                     ("1.0~rc1", "1.0~rc1", EQ),
-                     ("1.0~rc1", "1.0", LT),
-                     ("1.0", "1.0~rc1", GT),
-                     ("1.0~rc1", "1.0~rc2", LT),
-                     ("1.0~rc2", "1.0~rc1", GT),
-                     ("1.0~rc1~git123", "1.0~rc1~git123", EQ),
-                     ("1.0~rc1~git123", "1.0~rc1", LT),
-                     ("1.0~rc1", "1.0~rc1~git123", GT)
+                         ("1.0~rc1", "1.0~rc1", EQ),
+                         ("1.0~rc1", "1.0", LT),
+                         ("1.0", "1.0~rc1", GT),
+                         ("1.0~rc1", "1.0~rc2", LT),
+                         ("1.0~rc2", "1.0~rc1", GT),
+                         ("1.0~rc1~git123", "1.0~rc1~git123", EQ),
+                         ("1.0~rc1~git123", "1.0~rc1", LT),
+                         ("1.0~rc1", "1.0~rc1~git123", GT)
+                       ]
+
+        forM_ vercmpCases $ \(verA, verB, ord) ->
+          it (verA ++ " " ++ show ord ++ " " ++ verB) $
+            vercmp verA verB `shouldBe` ord
+
+    describe "RPM.Version.EVR Ord" $ do
+        let ordCases = [
+                     (EVR{epoch=Nothing, version="1.0", release="1"}, EVR{epoch=Nothing, version="1.0", release="1"}, EQ),
+                     (EVR{epoch=Just 0,  version="1.0", release="1"}, EVR{epoch=Nothing, version="1.0", release="1"}, EQ),
+                     (EVR{epoch=Just 1,  version="1.0", release="1"}, EVR{epoch=Nothing, version="1.0", release="1"}, GT),
+                     (EVR{epoch=Nothing, version="1.0", release="1"}, EVR{epoch=Nothing, version="1.1", release="1"}, LT),
+                     (EVR{epoch=Nothing, version="1.0", release="1"}, EVR{epoch=Nothing, version="1.0", release="2"}, LT),
+
+                     (EVR{epoch=Just 8,  version="3.6.9", release="11.fc100"}, EVR{epoch=Just 3,  version="3.6.9", release="11.fc100"}, GT),
+                     (EVR{epoch=Just 8,  version="3.6.9", release="11.fc100"}, EVR{epoch=Just 11, version="3.6.9", release="11.fc100"}, LT),
+                     (EVR{epoch=Just 8,  version="3.6.9", release="11.fc100"}, EVR{epoch=Just 8,  version="7.0",   release="11.fc100"}, LT),
+                     (EVR{epoch=Just 8,  version="3.6.9", release="11.fc100"}, EVR{epoch=Just 8,  version="",      release="11.fc100"}, GT),
+                     (EVR{epoch=Just 8,  version="",      release="11.fc100"}, EVR{epoch=Just 8,  version="",      release="11.fc100"}, EQ),
+
+                     (EVR{epoch=Nothing, version="1.1",  release="1"}, EVR{epoch=Nothing, version="1.01", release="1"}, EQ),
+                     (EVR{epoch=Nothing, version="1..1", release="1"}, EVR{epoch=Nothing, version="1.1",  release="1"}, EQ)
                    ]
 
-    forM_ versionCases $ \(verA, verB, ord) ->
-      it (verA ++ " " ++ show ord ++ " " ++ verB) $
-        vercmp verA verB `shouldBe` ord
+        forM_ ordCases $ \(verA, verB, ord) ->
+            it (show verA ++ " " ++ show ord ++ " " ++ show verB) $
+                compare verA verB `shouldBe` ord
+
+    describe "RPM.Version.satisfies" $ do
+        let satisfiesCases = [
+              ("no", "match", False),
+
+              ("thing",          "thing",          True),
+              ("thing",          "thing >= 1.0-1", True),
+              ("thing >= 1.0-1", "thing",          True),
+
+              ("thing = 1.0-1",  "thing = 1.0-1",  True),
+              ("thing = 1.0-1",  "thing >= 1.0-1", True),
+              ("thing = 1.0-1",  "thing > 1.0-1",  False),
+              ("thing = 1.0-1",  "thing < 1.0-1",  False),
+              ("thing = 1.0-1",  "thing <= 1.0-1", True),
+
+              ("thing = 1.0",    "thing = 1.0-9",   True),
+              ("thing = 1.0",    "thing < 1.0-9",   True),
+              ("thing = 1.0",    "thing <= 1.0-9",  True),
+              ("thing = 1.0",    "thing >= 1.0-9",  True),
+              ("thing = 1.0",    "thing > 1.0-9",   True),
+
+              ("thing = 1.0",    "thing = 1.0",     True),
+              ("thing = 1.0",    "thing < 1.0",     False),
+              ("thing = 1.0",    "thing > 1.0",     False),
+              ("thing = 1.0",    "thing >= 1.0",    True),
+              ("thing = 1.0",    "thing <= 1.0",    True),
+
+              ("thing < 1.0",    "thing = 1.0",     False),
+              ("thing < 1.0",    "thing < 1.0",     True),
+              ("thing < 1.0",    "thing > 1.0",     False),
+              ("thing < 1.0",    "thing >= 1.0",    False),
+              ("thing < 1.0",    "thing <= 1.0",    True),
+
+              ("thing > 1.0",    "thing = 1.0",     False),
+              ("thing > 1.0",    "thing < 1.0",     False),
+              ("thing > 1.0",    "thing > 1.0",     True),
+              ("thing > 1.0",    "thing >= 1.0",    True),
+              ("thing > 1.0",    "thing <= 1.0",    False),
+
+              ("thing >= 1.0",   "thing = 1.0",     True),
+              ("thing >= 1.0",   "thing < 1.0",     False),
+              ("thing >= 1.0",   "thing > 1.0",     True),
+              ("thing >= 1.0",   "thing >= 1.0",    True),
+              ("thing >= 1.0",   "thing <= 1.0",    True),
+
+              ("thing <= 1.0",   "thing = 1.0",     True),
+              ("thing <= 1.0",   "thing < 1.0",     True),
+              ("thing <= 1.0",   "thing > 1.0",     False),
+              ("thing <= 1.0",   "thing >= 1.0",    True),
+              ("thing <= 1.0",   "thing <= 1.0",    True),
+
+              ("thing <= 1.0",   "thing = 1.0-9",   True),
+              ("thing <= 1.0",   "thing < 1.0-9",   True),
+              ("thing <= 1.0",   "thing <= 1.0-9",  True),
+              ("thing <= 1.0",   "thing >= 1.0-9",  True),
+              ("thing <= 1.0",   "thing > 1.0-9",   True),
+
+              ("thing >= 1.0",   "thing = 1.0-9",   True),
+              ("thing >= 1.0",   "thing < 1.0-9",   True),
+              ("thing >= 1.0",   "thing <= 1.0-9",  True),
+              ("thing >= 1.0",   "thing >= 1.0-9",  True),
+              ("thing >= 1.0",   "thing > 1.0-9",   True),
+
+              ("thing = 1.0-9",  "thing = 1.0-9",   True),
+              ("thing < 1.0-9",  "thing = 1.0-9",   False),
+              ("thing <= 1.0-9", "thing = 1.0-9",   True),
+              ("thing > 1.0-9",  "thing = 1.0-9",   False),
+              ("thing >= 1.0-9", "thing = 1.0-9",   True),
+
+              ("thing >= 1.0-1", "thing = 1.0-1",  True),
+              ("thing >= 1.0-1", "thing >= 1.0-1", True),
+              ("thing >= 1.0-1", "thing > 1.0-1",  True),
+              ("thing >= 1.0-1", "thing < 1.0-1",  False),
+              ("thing >= 1.0-1", "thing <= 1.0-1", True),
+
+              ("thing > 1.0-1",  "thing = 1.0-1",  False),
+              ("thing > 1.0-1",  "thing >= 1.0-1", True),
+              ("thing > 1.0-1",  "thing > 1.0-1",  True),
+              ("thing > 1.0-1",  "thing < 1.0-1",  False),
+              ("thing > 1.0-1",  "thing <= 1.0-1", False),
+
+              ("thing < 1.0-1",  "thing = 1.0-1",  False),
+              ("thing < 1.0-1",  "thing >= 1.0-1", False),
+              ("thing < 1.0-1",  "thing > 1.0-1",  False),
+              ("thing < 1.0-1",  "thing < 1.0-1",  True),
+              ("thing < 1.0-1",  "thing <= 1.0-1", True),
+
+              ("thing <= 1.0-1", "thing = 1.0-1",  True),
+              ("thing <= 1.0-1", "thing >= 1.0-1", True),
+              ("thing <= 1.0-1", "thing > 1.0-1",  False),
+              ("thing <= 1.0-1", "thing < 1.0-1",  True),
+              ("thing <= 1.0-1", "thing <= 1.0-1", True),
+
+              ("thing = 9.0",    "thing = 1.0-1",  False),
+              ("thing = 9.0",    "thing >= 1.0-1", True),
+              ("thing = 9.0",    "thing > 1.0-1",  True),
+              ("thing = 9.0",    "thing <= 1.0-1", False),
+              ("thing = 9.0",    "thing < 1.0-1",  False),
+
+              ("thing < 9.0",    "thing = 1.0-1",  True),
+              ("thing < 9.0",    "thing >= 1.0-1", True),
+              ("thing < 9.0",    "thing > 1.0-1",  True),
+              ("thing < 9.0",    "thing <= 1.0-1", True),
+              ("thing < 9.0",    "thing < 1.0-1",  True),
+
+              ("thing <= 9.0",   "thing = 1.0-1",  True),
+              ("thing <= 9.0",   "thing >= 1.0-1", True),
+              ("thing <= 9.0",   "thing > 1.0-1",  True),
+              ("thing <= 9.0",   "thing <= 1.0-1", True),
+              ("thing <= 9.0",   "thing < 1.0-1",  True),
+
+              ("thing > 9.0",    "thing = 1.0-1",  False),
+              ("thing > 9.0",    "thing >= 1.0-1", True),
+              ("thing > 9.0",    "thing > 1.0-1",  True),
+              ("thing > 9.0",    "thing <= 1.0-1", False),
+              ("thing > 9.0",    "thing < 1.0-1",  False),
+
+              ("thing >= 9.0",   "thing = 1.0-1",  False),
+              ("thing >= 9.0",   "thing >= 1.0-1", True),
+              ("thing >= 9.0",   "thing > 1.0-1",  True),
+              ("thing >= 9.0",   "thing <= 1.0-1", False),
+              ("thing >= 9.0",   "thing < 1.0-1",  False),
+
+              ("thing = 1.0",    "thing = 9.0-1",  False),
+              ("thing = 1.0",    "thing >= 9.0-1", False),
+              ("thing = 1.0",    "thing > 9.0-1",  False),
+              ("thing = 1.0",    "thing <= 9.0-1", True),
+              ("thing = 1.0",    "thing < 9.0-1",  True),
+
+              ("thing < 1.0",    "thing = 9.0-1",  False),
+              ("thing < 1.0",    "thing >= 9.0-1", False),
+              ("thing < 1.0",    "thing > 9.0-1",  False),
+              ("thing < 1.0",    "thing <= 9.0-1", True),
+              ("thing < 1.0",    "thing < 9.0-1",  True),
+
+              ("thing <= 1.0",   "thing = 9.0-1",  False),
+              ("thing <= 1.0",   "thing >= 9.0-1", False),
+              ("thing <= 1.0",   "thing > 9.0-1",  False),
+              ("thing <= 1.0",   "thing <= 9.0-1", True),
+              ("thing <= 1.0",   "thing < 9.0-1",  True),
+
+              ("thing >= 1.0",   "thing = 9.0-1",  True),
+              ("thing >= 1.0",   "thing >= 9.0-1", True),
+              ("thing >= 1.0",   "thing > 9.0-1",  True),
+              ("thing >= 1.0",   "thing <= 9.0-1", True),
+              ("thing >= 1.0",   "thing < 9.0-1",  True),
+
+              ("thing > 1.0",    "thing = 9.0-1",  True),
+              ("thing > 1.0",    "thing >= 9.0-1", True),
+              ("thing > 1.0",    "thing > 9.0-1",  True),
+              ("thing > 1.0",    "thing <= 9.0-1", True),
+              ("thing > 1.0",    "thing < 9.0-1",  True)
+              ]
+
+        forM_ satisfiesCases $ \(v1, v2, b) ->
+            it (v1 ++ " " ++ v2 ++ ": " ++ show b) $
+                case (parseDepRequirement v1, parseDepRequirement v2) of
+                    (Right verA, Right verB) -> satisfies verA verB `shouldBe` b
+                    _                        -> expectationFailure "Unable to parse versions"
+
+    describe "RPM.Version.parseEVR" $ do
+        let parseEVRCases = [
+                ("1.0-11.fc100",    Right EVR{epoch=Nothing, version="1.0", release="11.fc100"}),
+                ("0:1.0-11.fc100",  Right EVR{epoch=Just 0,  version="1.0", release="11.fc100"}),
+                ("8:1.0-11.fc100",  Right EVR{epoch=Just 8,  version="1.0", release="11.fc100"}),
+                ("1.0",             Right EVR{epoch=Nothing, version="1.0", release=""}),
+                ("8:1.0",           Right EVR{epoch=Just 8,  version="1.0", release=""}),
+
+                -- missing epoch
+                (":1.0-11.fc100",   Left ()),
+
+                -- missing version
+                ("0:-11.fc100",     Left ()),
+
+                -- missing release
+                ("0:1.0-",          Left ()),
+
+                -- invalid epochs
+                ("-1:1.0-100.fc11", Left ()),
+                ("A:1.0-100.fc11",  Left ()),
+                ("8589934592:1.0-100.fc11", Left ()),
+
+                -- invalid versions
+                ("0:1.0:0-100.fc11",  Left ()),
+                ("0:1.0&0-100.fc11",  Left ()),
+                ("0:1.0\x01f32e\&0-100.fc11", Left ()),
+
+                -- invalid releases
+                ("0:1.0-100.fc:11",  Left ()),
+                ("0:1.0-100.fc&11",  Left ()),
+                ("0:1.0-100.fc\x01f32e\&11", Left ())
+                ]
+
+        -- For the error cases, we don't actually care about the contents of the error, so just
+        -- make sure parseEVR returns a Left. Also, the Either returned by parseEVR is not the
+        -- same type as the ones in the test cases (ParseError vs. ()), so unwrap the Right EVR
+        -- cases to compare.
+        -- Making fake ParseErrors is hard, so the Either returned by parseEVR is not the same type
+        -- as the either in the test data (ParseError vs. ()). Unwrap the Right values to compare EVRs,
+        -- and for parse errors just check that parseEVR returns a Left.
+        forM_ parseEVRCases $ \(str, result) ->
+            it str $ case (result, parseEVR str) of
+                (Right evr1, Right evr2) -> evr1 `shouldBe` evr2
+                (Left _, Right evr)      -> expectationFailure $ "bad string parsed as: " ++ show evr
+                (Right _, Left err)      -> expectationFailure $ "unable to parse valid EVR: " ++ show err
+                _                        -> return ()
+
+    describe "RPM.Version.parseDepRequirement" $ do
+        let parseDepRequirementCases = [
+                ("libthing",        DepRequirement "libthing" Nothing),
+                ("libthing >= 1.0", DepRequirement "libthing" $ Just (RPM.GTE, EVR{epoch=Nothing, version="1.0", release=""})),
+                ("libthing > 1.0",  DepRequirement "libthing" $ Just (RPM.GT,  EVR{epoch=Nothing, version="1.0", release=""})),
+                ("libthing = 1.0",  DepRequirement "libthing" $ Just (RPM.EQ,  EVR{epoch=Nothing, version="1.0", release=""})),
+                ("libthing < 1.0",  DepRequirement "libthing" $ Just (RPM.LT,  EVR{epoch=Nothing, version="1.0", release=""})),
+                ("libthing <= 1.0", DepRequirement "libthing" $ Just (RPM.LTE, EVR{epoch=Nothing, version="1.0", release=""})),
+
+                -- sometimes an RPM will have an invalid version in a Requires/Provides line.
+                -- make sure the whole thing gets parsed as a name
+                ("httpd-mmn = 20120211-x86-64", DepRequirement "httpd-mmn = 20120211-x86-64" Nothing)
+                ]
+
+        forM_ parseDepRequirementCases $ \(str, result) ->
+            it str $ case parseDepRequirement str of
+                Right dr -> dr `shouldBe` result
+                Left err -> expectationFailure $ "failed to parse DepRequirement: " ++ show err

--- a/tests/RPM/VersionSpec.hs
+++ b/tests/RPM/VersionSpec.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module RPM.VersionSpec (main, spec) where
 
-import Test.Hspec
-import Data.Foldable(forM_)
-import RPM.Version(DepRequirement(..), EVR(..), parseDepRequirement, parseEVR, satisfies, vercmp)
+import           Test.Hspec
+import           Data.Foldable(forM_)
+import qualified Data.Text as T
+import           RPM.Version(DepRequirement(..), EVR(..), parseDepRequirement, parseEVR, satisfies, vercmp)
 import qualified RPM.Version as RPM(DepOrdering(..))
 
 main :: IO ()
@@ -101,7 +104,7 @@ spec = do
                        ]
 
         forM_ vercmpCases $ \(verA, verB, ord) ->
-          it (verA ++ " " ++ show ord ++ " " ++ verB) $
+          it (T.unpack verA ++ " " ++ show ord ++ " " ++ T.unpack verB) $
             vercmp verA verB `shouldBe` ord
 
     describe "RPM.Version.EVR Ord" $ do
@@ -280,7 +283,7 @@ spec = do
               ]
 
         forM_ satisfiesCases $ \(v1, v2, b) ->
-            it (v1 ++ " " ++ v2 ++ ": " ++ show b) $
+            it (T.unpack v1 ++ " " ++ T.unpack v2 ++ ": " ++ show b) $
                 case (parseDepRequirement v1, parseDepRequirement v2) of
                     (Right verA, Right verB) -> satisfies verA verB `shouldBe` b
                     _                        -> expectationFailure "Unable to parse versions"
@@ -326,7 +329,7 @@ spec = do
         -- as the either in the test data (ParseError vs. ()). Unwrap the Right values to compare EVRs,
         -- and for parse errors just check that parseEVR returns a Left.
         forM_ parseEVRCases $ \(str, result) ->
-            it str $ case (result, parseEVR str) of
+            it (T.unpack str) $ case (result, parseEVR str) of
                 (Right evr1, Right evr2) -> evr1 `shouldBe` evr2
                 (Left _, Right evr)      -> expectationFailure $ "bad string parsed as: " ++ show evr
                 (Right _, Left err)      -> expectationFailure $ "unable to parse valid EVR: " ++ show err
@@ -347,6 +350,6 @@ spec = do
                 ]
 
         forM_ parseDepRequirementCases $ \(str, result) ->
-            it str $ case parseDepRequirement str of
+            it (T.unpack str) $ case parseDepRequirement str of
                 Right dr -> dr `shouldBe` result
                 Left err -> expectationFailure $ "failed to parse DepRequirement: " ++ show err


### PR DESCRIPTION
Add a new type, DepRequirement, which represents the name and optional
version information from a RPM PRCO header. A new function, satisfies,
determines whether a pair of DepRequirements match. For example, whether
Requires: libthing >= 1.0 is satisfied by Provides: libthing < 2.1.

Add tests for the new code, copied from bdcs-api-rs.