### PR TITLE
Switch to Hspec and update README with info about testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Executing unit tests
 
     $ cabal sandbox init
     $ cabal install --dependencies-only --enable-tests
-    $ cabal test
+    $ cabal test --show-details=always
     Preprocessing library rpm-1...
     Preprocessing test suite 'tests' for rpm-1...
     Running 1 test suites...
@@ -47,5 +47,5 @@ Produce code coverage report
 
     $ cabal sandbox init
     $ cabal install --enable-tests --enable-coverage
-    $ cabal test
+    $ cabal test --show-details=always
     $ firefox ./dist/hpc/vanilla/tix/*/hpc_index.html

--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ Produce code coverage report
     $ cabal install --enable-tests --enable-coverage
     $ cabal test --show-details=always
     $ firefox ./dist/hpc/vanilla/tix/*/hpc_index.html
+
+Testing in Haskell
+==================
+
+The recommended way to test this project is to use
+[Hspec](https://hspec.github.io/) for annotating unit tests.
+For starters you can try adding cases which extend code coverage.
+
+It is also recommended to use property based testing with
+QuickCheck (and Hspec) where it makes sense. Property based tools
+automatically generates hundreds/thousands of input variants and
+execute the function under test with them. This validates that
+specific conditions (aka properties of the function) are always met.
+This is useful with pure functions. For more information see:
+
+- http://blog.jessitron.com/2013/04/property-based-testing-what-is-it.html
+- http://book.realworldhaskell.org/read/testing-and-quality-assurance.html
+- https://en.wikibooks.org/wiki/Haskell/Testing
+- http://hspec.github.io/quickcheck.html

--- a/rpm.cabal
+++ b/rpm.cabal
@@ -99,12 +99,11 @@ executable rpm2json
 test-suite tests
     type:               exitcode-stdio-1.0
     hs-source-dirs:     tests
-    main-is:            Main.hs
+    main-is:            Spec.hs
     
     build-depends:      HUnit,
+                        hspec,
                         base >= 4.7 && < 5.0,
-                        tasty,
-                        tasty-hunit,
                         rpm
 
     default-language:   Haskell2010

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,8 +1,0 @@
-module Main(main) where
-
-import           Test.Tasty(defaultMain, testGroup)
-import qualified RPM.Version.Tests
-
-main :: IO ()
-main = defaultMain $ testGroup "Tests"
-    [ RPM.Version.Tests.vercmpTests ]

--- a/tests/RPM/VersionSpec.hs
+++ b/tests/RPM/VersionSpec.hs
@@ -1,20 +1,16 @@
-module RPM.Version.Tests(vercmpTests)
- where
+module RPM.VersionSpec (main, spec) where
 
-import Test.Tasty(TestTree, testGroup)
-import Test.Tasty.HUnit(assertEqual, testCase)
-
+import Test.Hspec
+import Data.Foldable(forM_)
 import RPM.Version(vercmp)
 
-vercmpTests :: TestTree
-vercmpTests = testGroup "vercmp tests" $ map verTestCase versionCases
- where
-    verTestCase :: (String, String, Ordering) -> TestTree
-    verTestCase (verA, verB, ord) = testCase (verA ++ " " ++ show ord ++ " " ++ verB) $
-        assertEqual "" ord (vercmp verA verB)
+main :: IO ()
+main = hspec spec
 
-    versionCases :: [(String, String, Ordering)]
-    versionCases = [ ("1.0", "1.0", EQ),
+spec :: Spec
+spec = describe "RPM.Version.vercmp" $ do
+    let versionCases = [
+                     ("1.0", "1.0", EQ),
                      ("1.0", "2.0", LT),
                      ("2.0", "1.0", GT),
 
@@ -101,3 +97,7 @@ vercmpTests = testGroup "vercmp tests" $ map verTestCase versionCases
                      ("1.0~rc1~git123", "1.0~rc1", LT),
                      ("1.0~rc1", "1.0~rc1~git123", GT)
                    ]
+
+    forM_ versionCases $ \(verA, verB, ord) ->
+      it (verA ++ " " ++ show ord ++ " " ++ verB) $
+        vercmp verA verB `shouldBe` ord

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Turned out the switch from tasty-hunit to hspec was very simple (we only got one test). Also added some examples and links to README to avoid passing Google docs around.

@clumens, @dashea please review.