### PR TITLE
Add more tests for Tags.hs

### DIFF
--- a/tests/RPM/TagsSpec.hs
+++ b/tests/RPM/TagsSpec.hs
@@ -516,3 +516,140 @@ spec = describe "RPM.Tags" $
             tag == Just (Encoding "test-me") || -- 5062
             tag == Just (INTERNAL (RemovePathPostFixes "test-me")) -- 5083
             `shouldBe` True
+
+    -- tests for tags which use mkStringArray
+    forM_ [100, 266,
+            1017, 1018, 1019, 1027, 1035, 1036, 1039, 1040,
+            1047, 1049, 1050, 1054, 1055, 1059, 1060, 1061,
+            1062, 1065, 1066, 1067, 1081, 1082, 1085, 1086,
+            1087, 1088, 1089, 1090, 1091, 1092, 1097, 1098,
+            1099, 1113, 1115, 1117, 1118, 1120, 1121, 1133,
+            1135, 1142, 1147, 1148, 1149, 1150, 1153, 1154, 1156,
+            1157, 1159, 1160, 1164, 1165, 1166, 1167, 1167,
+            1168, 1169, 1178, 1182, 1183, 1186, 1188,
+            5000, 5001, 5002, 5003, 5005, 5006, 5007, 5010,
+            5029, 5030, 5031, 5035, 5036, 5038, 5039, 5040,
+            5041, 5042, 5043, 5044, 5046, 5047, 5049, 5050,
+            5052, 5053, 5055, 5056, 5058, 5059, 5060, 5061,
+            5066, 5067, 5069, 5071, 5076, 5077, 5079, 5081,
+             5086, 5087, 5088, 5089, 5090] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 8") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 8 0 7
+
+        tag == Just (HeaderI18NTable ["test-me"]) || -- 100
+            tag == Just (PubKeys ["test-me"]) || -- 266
+            tag == Just (INTERNAL (ChangeLog ["test-me"])) || -- 1017
+            tag == Just (Source ["test-me"]) || -- 1018
+            tag == Just (Patch ["test-me"]) || -- 1019
+            tag == Just (OBSOLETE (OldFileNames ["test-me"])) || -- 1027
+            tag == Just (FileMD5s ["test-me"]) || -- 1035
+            tag == Just (FileLinkTos ["test-me"]) || -- 1036
+            tag == Just (FileUserName ["test-me"]) || -- 1039
+            tag == Just (FileGroupName ["test-me"]) || -- 1040
+            tag == Just (ProvideName ["test-me"]) || -- 1047
+            tag == Just (RequireName ["test-me"]) || -- 1049
+            tag == Just (RequireVersion ["test-me"]) || -- 1050
+            tag == Just (ConflictName ["test-me"]) || -- 1054
+            tag == Just (ConflictVersion ["test-me"]) || -- 1055
+            tag == Just (ExcludeArch ["test-me"]) || -- 1059
+            tag == Just (ExcludeOS ["test-me"]) || -- 1060
+            tag == Just (ExclusiveArch ["test-me"]) || -- 1061
+            tag == Just (ExclusiveOS ["test-me"]) || -- 1062
+            tag == Just (TriggerScripts ["test-me"]) || -- 1065
+            tag == Just (TriggerName ["test-me"]) || -- 1066
+            tag == Just (TriggerVersion ["test-me"]) || -- 1067
+            tag == Just (ChangeLogName ["test-me"]) || -- 1081
+            tag == Just (ChangeLogText ["test-me"]) || -- 1082
+            tag == Just (PreInProg ["test-me"]) || -- 1085
+            tag == Just (PostInProg ["test-me"]) || -- 1086
+            tag == Just (PreUnProg ["test-me"]) || -- 1087
+            tag == Just (PostUnProg ["test-me"]) || -- 1088
+            tag == Just (BuildArchs ["test-me"]) || -- 1089
+            tag == Just (ObsoleteName ["test-me"]) || -- 1090
+            tag == Just (VerifyScriptProg ["test-me"]) || -- 1091
+            tag == Just (TriggerScriptProg ["test-me"]) || -- 1092
+            tag == Just (FileLangs ["test-me"]) || -- 1097
+            tag == Just (Prefixes ["test-me"]) || -- 1098
+            tag == Just (InstPrefixes ["test-me"]) || -- 1099
+            tag == Just (ProvideVersion ["test-me"]) || -- 1113
+            tag == Just (ObsoleteVersion ["test-me"]) || -- 1115
+            tag == Just (BaseNames ["test-me"]) || -- 1117
+            tag == Just (DirNames ["test-me"]) || -- 1118
+            tag == Just (OrigBaseNames ["test-me"]) || -- 1120
+            tag == Just (OrigDirNames ["test-me"]) || -- 1121
+            tag == Just (DEPRECATED (PatchesName ["test-me"])) || -- 1133
+            tag == Just (DEPRECATED (PatchesVersion ["test-me"])) || -- 1135
+            tag == Just (ClassDict ["test-me"]) || -- 1142
+            tag == Just (OBSOLETE (FileContexts ["test-me"])) || -- 1147
+            tag == Just (FSContexts ["test-me"]) || -- 1148
+            tag == Just (ReContexts ["test-me"]) || -- 1149
+            tag == Just (Policies ["test-me"]) || -- 1150
+            tag == Just (PreTransProg ["test-me"]) || -- 1153
+            tag == Just (PostTransProg ["test-me"]) || -- 1154
+            tag == Just (OBSOLETE (OldSuggestsName ["test-me"])) || -- 1156
+            tag == Just (OBSOLETE (OldSuggestsVersion ["test-me"])) || -- 1157
+            tag == Just (OBSOLETE (OldEnhancesName ["test-me"])) || -- 1159
+            tag == Just (OBSOLETE (OldEnhancesVersion ["test-me"])) || -- 1160
+            tag == Just (UNIMPLEMENTED (BLinkPkgID ["test-me"])) || -- 1164
+            tag == Just (UNIMPLEMENTED (BLinkHdrID ["test-me"])) || -- 1165
+            tag == Just (UNIMPLEMENTED (BLinkNEVRA ["test-me"])) || -- 1166
+            tag == Just (UNIMPLEMENTED (FLinkPkgID ["test-me"])) || -- 1167
+            tag == Just (UNIMPLEMENTED (FLinkHdrID ["test-me"])) || -- 1168
+            tag == Just (UNIMPLEMENTED (FLinkNEVRA ["test-me"])) || -- 1169
+            tag == Just (UNIMPLEMENTED (Variants["test-me"])) || -- 1178
+            tag == Just (UNIMPLEMENTED (Keywords["test-me"])) || -- 1182
+            tag == Just (UNIMPLEMENTED (BuildPlatforms["test-me"])) || -- 1183
+            tag == Just (UNIMPLEMENTED (XattrsDict["test-me"])) || -- 1186
+            tag == Just (UNIMPLEMENTED (DepAttrsDict["test-me"])) || -- 1188
+            tag == Just (FileNames ["test-me"]) || -- 5000
+            tag == Just (FileProvide ["test-me"]) || -- 5001
+            tag == Just (FileRequire ["test-me"]) || -- 5002
+            tag == Just (UNIMPLEMENTED (FSNames ["test-me"])) || -- 5003
+            tag == Just (TriggerConds ["test-me"]) || -- 5005
+            tag == Just (TriggerType ["test-me"]) || -- 5006
+            tag == Just (OrigFileNames ["test-me"]) || -- 5007
+            tag == Just (FileCaps ["test-me"]) || -- 5010
+            tag == Just (UNIMPLEMENTED (Collections ["test-me"])) || -- 5029
+            tag == Just (PolicyNames ["test-me"]) || -- 5030
+            tag == Just (PolicyTypes ["test-me"]) || -- 5031
+            tag == Just (OrderName ["test-me"]) || -- 5035
+            tag == Just (OrderVersion ["test-me"]) || -- 5036
+            tag == Just (UNIMPLEMENTED (MSSFManifest ["test-me"])) || -- 5038
+            tag == Just (UNIMPLEMENTED (MSSFDomain ["test-me"])) || -- 5039
+            tag == Just (InstFileNames ["test-me"]) || -- 5040
+            tag == Just (RequireNEVRs ["test-me"]) || -- 5041
+            tag == Just (ProvideNEVRs ["test-me"]) || -- 5042
+            tag == Just (ObsoleteNEVRs ["test-me"]) || -- 5043
+            tag == Just (ConflictNEVRs ["test-me"]) || -- 5044
+            tag == Just (RecommendName ["test-me"]) || -- 5046
+            tag == Just (RecommendVersion ["test-me"]) || -- 5047
+            tag == Just (SuggestName ["test-me"]) || -- 5049
+            tag == Just (SuggestVersion ["test-me"]) || -- 5050
+            tag == Just (SupplementName ["test-me"]) || -- 5052
+            tag == Just (SupplementVersion ["test-me"]) || -- 5053
+            tag == Just (EnhanceName ["test-me"]) || -- 5055
+            tag == Just (EnhanceVersion ["test-me"]) || -- 5056
+            tag == Just (RecommendNEVRs ["test-me"]) || -- 5058
+            tag == Just (SuggestNEVRs ["test-me"]) || -- 5059
+            tag == Just (SupplementNEVRs ["test-me"]) || -- 5060
+            tag == Just (EnhanceNEVRs ["test-me"]) || -- 5061
+            tag == Just (FileTriggerScripts ["test-me"]) || -- 5066
+            tag == Just (FileTriggerScriptProg ["test-me"]) || -- 5067
+            tag == Just (FileTriggerName ["test-me"]) || -- 5069
+            tag == Just (FileTriggerVersion ["test-me"]) || -- 5071
+            tag == Just (TransFileTriggerScripts ["test-me"]) || -- 5076
+            tag == Just (TransFileTriggerScriptProg ["test-me"]) || -- 5077
+            tag == Just (TransFileTriggerName ["test-me"]) || -- 5079
+            tag == Just (TransFileTriggerVersion ["test-me"]) || -- 5081
+            tag == Just (FileTriggerConds ["test-me"]) || -- 5086
+            tag == Just (FileTriggerType ["test-me"]) || -- 5087
+            tag == Just (TransFileTriggerConds ["test-me"]) || -- 5088
+            tag == Just (TransFileTriggerType ["test-me"]) || -- 5089
+            tag == Just (FileSignatures ["test-me"]) -- 5090
+            `shouldBe` True

--- a/tests/RPM/TagsSpec.hs
+++ b/tests/RPM/TagsSpec.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import Data.Foldable(forM_)
 import RPM.Tags(mkTag, Tag(..), Null(..))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 
@@ -68,6 +69,20 @@ spec = describe "RPM.Tags" $
             tag == Just (INTERNAL (TransFileTriggerIn Null)) || -- 5073
             tag == Just (INTERNAL (TransFileTriggerUn Null)) || -- 5074
             tag == Just (INTERNAL (TransFileTriggerPostUn Null)) -- 5075
+            `shouldBe` True
+
+    -- tests for tags which use mkChar
+    forM_ [1029] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 1") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "5"
+        let tag = mkTag store tagInt 1 0 1
+
+        tag == Just (FileStates "5") -- 1029
             `shouldBe` True
 
     -- tests for tags which use mkWord16
@@ -215,4 +230,223 @@ spec = describe "RPM.Tags" $
             tag == Just (UNIMPLEMENTED (FSSizes [5])) || -- 5004
             tag == Just (LongFileSizes [5]) || -- 5008
             tag == Just (LongSize 5) -- 5009
+            `shouldBe` True
+
+    -- tests for tags which use mkString
+    forM_ [269,
+            1000, 1001, 1002, 1007, 1010, 1011, 1014, 1015,
+            1020, 1021, 1022, 1023, 1024, 1025, 1026, 1044,
+            1056, 1057, 1058, 1063, 1064, 1079, 1094,
+            1122, 1123, 1124, 1125, 1126, 1131, 1132, 1137,
+            1151, 1152, 1155, 1163, 1170, 1181, 1196,
+            5012, 5013, 5014, 5015, 5016, 5034, 5062, 5083] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 6") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 6 0 7
+
+        tag == Just (SHA1Header "test-me") || -- 269
+            tag == Just (Name "test-me") || -- 1000
+            tag == Just (Version "test-me") || -- 1001
+            tag == Just (Release "test-me") || -- 1002
+            tag == Just (BuildHost "test-me") || -- 1007
+            tag == Just (Distribution "test-me") || -- 1010
+            tag == Just (Vendor "test-me") || -- 1011
+            tag == Just (License "test-me") || -- 1014
+            tag == Just (Packager "test-me") || -- 1015
+            tag == Just (URL "test-me") || -- 1020
+            tag == Just (OS "test-me") || -- 1021
+            tag == Just (Arch "test-me") || -- 1022
+            tag == Just (PreIn "test-me") || -- 1023
+            tag == Just (PostIn "test-me") || -- 1024
+            tag == Just (PreUn "test-me") || -- 1025
+            tag == Just (PostUn "test-me") || -- 1026
+            tag == Just (SourceRPM "test-me") || -- 1044
+            tag == Just (INTERNAL (DEPRECATED (DefaultPrefix "test-me"))) || -- 1056
+            tag == Just (INTERNAL (OBSOLETE (BuildRoot "test-me"))) || -- 1057
+            tag == Just (INTERNAL (DEPRECATED (InstallPrefix "test-me"))) || -- 1058
+            tag == Just (INTERNAL (AutoReqProv "test-me")) || -- 1063
+            tag == Just (RPMVersion "test-me") || -- 1064
+            tag == Just (VerifyScript "test-me") || -- 1079
+            tag == Just (Cookie "test-me") || -- 1094
+            tag == Just (OptFlags "test-me") || -- 1122
+            tag == Just (DistURL "test-me") || -- 1123
+            tag == Just (PayloadFormat "test-me") || -- 1124
+            tag == Just (PayloadCompressor "test-me") || -- 1125
+            tag == Just (PayloadFlags "test-me") || -- 1126
+            tag == Just (INTERNAL (OBSOLETE (RHNPlatform "test-me"))) || -- 1131
+            tag == Just (Platform "test-me") || -- 1132
+            tag == Just (INTERNAL (OBSOLETE (CachePkgPath "test-me"))) || -- 1137
+            tag == Just (PreTrans "test-me") || -- 1151
+            tag == Just (PostTrans "test-me") || -- 1152
+            tag == Just (DistTag "test-me") || -- 1155
+            tag == Just (UNIMPLEMENTED (CVSID "test-me")) || -- 1163
+            tag == Just (UNIMPLEMENTED (PackageOrigin "test-me")) || -- 1170
+            tag == Just (UNIMPLEMENTED (RepoTag "test-me")) || -- 1181
+            tag == Just (NVRA "test-me") || -- 1196
+            tag == Just (BugURL "test-me") || -- 5012
+            tag == Just (EVR "test-me") || -- 5013
+            tag == Just (NVR "test-me") || -- 5014
+            tag == Just (NEVR "test-me") || -- 5015
+            tag == Just (NEVRA "test-me") || -- 5016
+            tag == Just (PolicyVCS "test-me") || -- 5034
+            tag == Just (Encoding "test-me") || -- 5062
+            tag == Just (INTERNAL (RemovePathPostFixes "test-me")) -- 5083
+            `shouldBe` True
+
+    -- tests for tags which use mkStringArray
+    forM_ [100, 266,
+            1017, 1018, 1019, 1027, 1035, 1036, 1039, 1040,
+            1047, 1049, 1050, 1054, 1055, 1059, 1060, 1061,
+            1062, 1065, 1066, 1067, 1081, 1082, 1085, 1086,
+            1087, 1088, 1089, 1090, 1091, 1092, 1097, 1098,
+            1099, 1113, 1115, 1117, 1118, 1120, 1121, 1133,
+            1135, 1142, 1147, 1148, 1149, 1150, 1153, 1154, 1156,
+            1157, 1159, 1160, 1164, 1165, 1166, 1167, 1167,
+            1168, 1169, 1178, 1182, 1183, 1186, 1188,
+            5000, 5001, 5002, 5003, 5005, 5006, 5007, 5010,
+            5029, 5030, 5031, 5035, 5036, 5038, 5039, 5040,
+            5041, 5042, 5043, 5044, 5046, 5047, 5049, 5050,
+            5052, 5053, 5055, 5056, 5058, 5059, 5060, 5061,
+            5066, 5067, 5069, 5071, 5076, 5077, 5079, 5081,
+             5086, 5087, 5088, 5089, 5090] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 8") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 8 0 7
+
+        tag == Just (HeaderI18NTable ["test-me"]) || -- 100
+            tag == Just (PubKeys ["test-me"]) || -- 266
+            tag == Just (INTERNAL (ChangeLog ["test-me"])) || -- 1017
+            tag == Just (Source ["test-me"]) || -- 1018
+            tag == Just (Patch ["test-me"]) || -- 1019
+            tag == Just (OBSOLETE (OldFileNames ["test-me"])) || -- 1027
+            tag == Just (FileMD5s ["test-me"]) || -- 1035
+            tag == Just (FileLinkTos ["test-me"]) || -- 1036
+            tag == Just (FileUserName ["test-me"]) || -- 1039
+            tag == Just (FileGroupName ["test-me"]) || -- 1040
+            tag == Just (ProvideName ["test-me"]) || -- 1047
+            tag == Just (RequireName ["test-me"]) || -- 1049
+            tag == Just (RequireVersion ["test-me"]) || -- 1050
+            tag == Just (ConflictName ["test-me"]) || -- 1054
+            tag == Just (ConflictVersion ["test-me"]) || -- 1055
+            tag == Just (ExcludeArch ["test-me"]) || -- 1059
+            tag == Just (ExcludeOS ["test-me"]) || -- 1060
+            tag == Just (ExclusiveArch ["test-me"]) || -- 1061
+            tag == Just (ExclusiveOS ["test-me"]) || -- 1062
+            tag == Just (TriggerScripts ["test-me"]) || -- 1065
+            tag == Just (TriggerName ["test-me"]) || -- 1066
+            tag == Just (TriggerVersion ["test-me"]) || -- 1067
+            tag == Just (ChangeLogName ["test-me"]) || -- 1081
+            tag == Just (ChangeLogText ["test-me"]) || -- 1082
+            tag == Just (PreInProg ["test-me"]) || -- 1085
+            tag == Just (PostInProg ["test-me"]) || -- 1086
+            tag == Just (PreUnProg ["test-me"]) || -- 1087
+            tag == Just (PostUnProg ["test-me"]) || -- 1088
+            tag == Just (BuildArchs ["test-me"]) || -- 1089
+            tag == Just (ObsoleteName ["test-me"]) || -- 1090
+            tag == Just (VerifyScriptProg ["test-me"]) || -- 1091
+            tag == Just (TriggerScriptProg ["test-me"]) || -- 1092
+            tag == Just (FileLangs ["test-me"]) || -- 1097
+            tag == Just (Prefixes ["test-me"]) || -- 1098
+            tag == Just (InstPrefixes ["test-me"]) || -- 1099
+            tag == Just (ProvideVersion ["test-me"]) || -- 1113
+            tag == Just (ObsoleteVersion ["test-me"]) || -- 1115
+            tag == Just (BaseNames ["test-me"]) || -- 1117
+            tag == Just (DirNames ["test-me"]) || -- 1118
+            tag == Just (OrigBaseNames ["test-me"]) || -- 1120
+            tag == Just (OrigDirNames ["test-me"]) || -- 1121
+            tag == Just (DEPRECATED (PatchesName ["test-me"])) || -- 1133
+            tag == Just (DEPRECATED (PatchesVersion ["test-me"])) || -- 1135
+            tag == Just (ClassDict ["test-me"]) || -- 1142
+            tag == Just (OBSOLETE (FileContexts ["test-me"])) || -- 1147
+            tag == Just (FSContexts ["test-me"]) || -- 1148
+            tag == Just (ReContexts ["test-me"]) || -- 1149
+            tag == Just (Policies ["test-me"]) || -- 1150
+            tag == Just (PreTransProg ["test-me"]) || -- 1153
+            tag == Just (PostTransProg ["test-me"]) || -- 1154
+            tag == Just (OBSOLETE (OldSuggestsName ["test-me"])) || -- 1156
+            tag == Just (OBSOLETE (OldSuggestsVersion ["test-me"])) || -- 1157
+            tag == Just (OBSOLETE (OldEnhancesName ["test-me"])) || -- 1159
+            tag == Just (OBSOLETE (OldEnhancesVersion ["test-me"])) || -- 1160
+            tag == Just (UNIMPLEMENTED (BLinkPkgID ["test-me"])) || -- 1164
+            tag == Just (UNIMPLEMENTED (BLinkHdrID ["test-me"])) || -- 1165
+            tag == Just (UNIMPLEMENTED (BLinkNEVRA ["test-me"])) || -- 1166
+            tag == Just (UNIMPLEMENTED (FLinkPkgID ["test-me"])) || -- 1167
+            tag == Just (UNIMPLEMENTED (FLinkHdrID ["test-me"])) || -- 1168
+            tag == Just (UNIMPLEMENTED (FLinkNEVRA ["test-me"])) || -- 1169
+            tag == Just (UNIMPLEMENTED (Variants["test-me"])) || -- 1178
+            tag == Just (UNIMPLEMENTED (Keywords["test-me"])) || -- 1182
+            tag == Just (UNIMPLEMENTED (BuildPlatforms["test-me"])) || -- 1183
+            tag == Just (UNIMPLEMENTED (XattrsDict["test-me"])) || -- 1186
+            tag == Just (UNIMPLEMENTED (DepAttrsDict["test-me"])) || -- 1188
+            tag == Just (FileNames ["test-me"]) || -- 5000
+            tag == Just (FileProvide ["test-me"]) || -- 5001
+            tag == Just (FileRequire ["test-me"]) || -- 5002
+            tag == Just (UNIMPLEMENTED (FSNames ["test-me"])) || -- 5003
+            tag == Just (TriggerConds ["test-me"]) || -- 5005
+            tag == Just (TriggerType ["test-me"]) || -- 5006
+            tag == Just (OrigFileNames ["test-me"]) || -- 5007
+            tag == Just (FileCaps ["test-me"]) || -- 5010
+            tag == Just (UNIMPLEMENTED (Collections ["test-me"])) || -- 5029
+            tag == Just (PolicyNames ["test-me"]) || -- 5030
+            tag == Just (PolicyTypes ["test-me"]) || -- 5031
+            tag == Just (OrderName ["test-me"]) || -- 5035
+            tag == Just (OrderVersion ["test-me"]) || -- 5036
+            tag == Just (UNIMPLEMENTED (MSSFManifest ["test-me"])) || -- 5038
+            tag == Just (UNIMPLEMENTED (MSSFDomain ["test-me"])) || -- 5039
+            tag == Just (InstFileNames ["test-me"]) || -- 5040
+            tag == Just (RequireNEVRs ["test-me"]) || -- 5041
+            tag == Just (ProvideNEVRs ["test-me"]) || -- 5042
+            tag == Just (ObsoleteNEVRs ["test-me"]) || -- 5043
+            tag == Just (ConflictNEVRs ["test-me"]) || -- 5044
+            tag == Just (RecommendName ["test-me"]) || -- 5046
+            tag == Just (RecommendVersion ["test-me"]) || -- 5047
+            tag == Just (SuggestName ["test-me"]) || -- 5049
+            tag == Just (SuggestVersion ["test-me"]) || -- 5050
+            tag == Just (SupplementName ["test-me"]) || -- 5052
+            tag == Just (SupplementVersion ["test-me"]) || -- 5053
+            tag == Just (EnhanceName ["test-me"]) || -- 5055
+            tag == Just (EnhanceVersion ["test-me"]) || -- 5056
+            tag == Just (RecommendNEVRs ["test-me"]) || -- 5058
+            tag == Just (SuggestNEVRs ["test-me"]) || -- 5059
+            tag == Just (SupplementNEVRs ["test-me"]) || -- 5060
+            tag == Just (EnhanceNEVRs ["test-me"]) || -- 5061
+            tag == Just (FileTriggerScripts ["test-me"]) || -- 5066
+            tag == Just (FileTriggerScriptProg ["test-me"]) || -- 5067
+            tag == Just (FileTriggerName ["test-me"]) || -- 5069
+            tag == Just (FileTriggerVersion ["test-me"]) || -- 5071
+            tag == Just (TransFileTriggerScripts ["test-me"]) || -- 5076
+            tag == Just (TransFileTriggerScriptProg ["test-me"]) || -- 5077
+            tag == Just (TransFileTriggerName ["test-me"]) || -- 5079
+            tag == Just (TransFileTriggerVersion ["test-me"]) || -- 5081
+            tag == Just (FileTriggerConds ["test-me"]) || -- 5086
+            tag == Just (FileTriggerType ["test-me"]) || -- 5087
+            tag == Just (TransFileTriggerConds ["test-me"]) || -- 5088
+            tag == Just (TransFileTriggerType ["test-me"]) || -- 5089
+            tag == Just (FileSignatures ["test-me"]) -- 5090
+            `shouldBe` True
+
+    -- tests for tags which use mkI18NString
+    forM_ [1004, 1005, 1016] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 9") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 9 0 7
+
+        tag == Just (Summary store) || -- 1004
+            tag == Just (Description store) || -- 1005
+            tag == Just (Group store) -- 1016
             `shouldBe` True

--- a/tests/RPM/TagsSpec.hs
+++ b/tests/RPM/TagsSpec.hs
@@ -450,3 +450,69 @@ spec = describe "RPM.Tags" $
             tag == Just (Description store) || -- 1005
             tag == Just (Group store) -- 1016
             `shouldBe` True
+
+    -- tests for tags which use mkString
+    forM_ [269,
+            1000, 1001, 1002, 1007, 1010, 1011, 1014, 1015,
+            1020, 1021, 1022, 1023, 1024, 1025, 1026, 1044,
+            1056, 1057, 1058, 1063, 1064, 1079, 1094,
+            1122, 1123, 1124, 1125, 1126, 1131, 1132, 1137,
+            1151, 1152, 1155, 1163, 1170, 1181, 1196,
+            5012, 5013, 5014, 5015, 5016, 5034, 5062, 5083] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 6") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 6 0 7
+
+        tag == Just (SHA1Header "test-me") || -- 269
+            tag == Just (Name "test-me") || -- 1000
+            tag == Just (Version "test-me") || -- 1001
+            tag == Just (Release "test-me") || -- 1002
+            tag == Just (BuildHost "test-me") || -- 1007
+            tag == Just (Distribution "test-me") || -- 1010
+            tag == Just (Vendor "test-me") || -- 1011
+            tag == Just (License "test-me") || -- 1014
+            tag == Just (Packager "test-me") || -- 1015
+            tag == Just (URL "test-me") || -- 1020
+            tag == Just (OS "test-me") || -- 1021
+            tag == Just (Arch "test-me") || -- 1022
+            tag == Just (PreIn "test-me") || -- 1023
+            tag == Just (PostIn "test-me") || -- 1024
+            tag == Just (PreUn "test-me") || -- 1025
+            tag == Just (PostUn "test-me") || -- 1026
+            tag == Just (SourceRPM "test-me") || -- 1044
+            tag == Just (INTERNAL (DEPRECATED (DefaultPrefix "test-me"))) || -- 1056
+            tag == Just (INTERNAL (OBSOLETE (BuildRoot "test-me"))) || -- 1057
+            tag == Just (INTERNAL (DEPRECATED (InstallPrefix "test-me"))) || -- 1058
+            tag == Just (INTERNAL (AutoReqProv "test-me")) || -- 1063
+            tag == Just (RPMVersion "test-me") || -- 1064
+            tag == Just (VerifyScript "test-me") || -- 1079
+            tag == Just (Cookie "test-me") || -- 1094
+            tag == Just (OptFlags "test-me") || -- 1122
+            tag == Just (DistURL "test-me") || -- 1123
+            tag == Just (PayloadFormat "test-me") || -- 1124
+            tag == Just (PayloadCompressor "test-me") || -- 1125
+            tag == Just (PayloadFlags "test-me") || -- 1126
+            tag == Just (INTERNAL (OBSOLETE (RHNPlatform "test-me"))) || -- 1131
+            tag == Just (Platform "test-me") || -- 1132
+            tag == Just (INTERNAL (OBSOLETE (CachePkgPath "test-me"))) || -- 1137
+            tag == Just (PreTrans "test-me") || -- 1151
+            tag == Just (PostTrans "test-me") || -- 1152
+            tag == Just (DistTag "test-me") || -- 1155
+            tag == Just (UNIMPLEMENTED (CVSID "test-me")) || -- 1163
+            tag == Just (UNIMPLEMENTED (PackageOrigin "test-me")) || -- 1170
+            tag == Just (UNIMPLEMENTED (RepoTag "test-me")) || -- 1181
+            tag == Just (NVRA "test-me") || -- 1196
+            tag == Just (BugURL "test-me") || -- 5012
+            tag == Just (EVR "test-me") || -- 5013
+            tag == Just (NVR "test-me") || -- 5014
+            tag == Just (NEVR "test-me") || -- 5015
+            tag == Just (NEVRA "test-me") || -- 5016
+            tag == Just (PolicyVCS "test-me") || -- 5034
+            tag == Just (Encoding "test-me") || -- 5062
+            tag == Just (INTERNAL (RemovePathPostFixes "test-me")) -- 5083
+            `shouldBe` True

--- a/tests/RPM/TagsSpec.hs
+++ b/tests/RPM/TagsSpec.hs
@@ -653,3 +653,19 @@ spec = describe "RPM.Tags" $
             tag == Just (TransFileTriggerType ["test-me"]) || -- 5089
             tag == Just (FileSignatures ["test-me"]) -- 5090
             `shouldBe` True
+
+    -- tests for tags which use mkI18NString
+    forM_ [1004, 1005, 1016] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 9") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 9 0 7
+
+        tag == Just (Summary store) || -- 1004
+            tag == Just (Description store) || -- 1005
+            tag == Just (Group store) -- 1016
+            `shouldBe` True

--- a/tests/RPM/TagsSpec.hs
+++ b/tests/RPM/TagsSpec.hs
@@ -298,6 +298,29 @@ spec = describe "RPM.Tags" $
             tag == Just (INTERNAL (RemovePathPostFixes "test-me")) -- 5083
             `shouldBe` True
 
+    -- tests for tags which use mkBinary
+    forM_ [259, 261, 262, 267, 268,
+            1012, 1013, 1043, 1146] $ \tagInt -> do
+      it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 7") $ do
+        let store = BS.pack [0]
+        let tag = mkTag store tagInt 99 0 0
+        tag `shouldBe` Nothing
+
+      it ("returns correct value for `tag' == " ++ show tagInt) $ do
+        let store = BC.pack "test-me"
+        let tag = mkTag store tagInt 7 0 7
+
+        tag == Just (SigPGP store) || -- 259
+            tag == Just (SigMD5 store) || -- 261
+            tag == Just (SigGPG store) || -- 262
+            tag == Just (DSAHeader store) || -- 267
+            tag == Just (RSAHeader store) || -- 268
+            tag == Just (GIF store) || -- 1012
+            tag == Just (XPM store) || -- 1013
+            tag == Just (Icon store) || -- 1043
+            tag == Just (SourcePkgID store) -- 1146
+            `shouldBe` True
+
     -- tests for tags which use mkStringArray
     forM_ [100, 266,
             1017, 1018, 1019, 1027, 1035, 1036, 1039, 1040,

--- a/tests/RPM/Tags_TagSpec.hs
+++ b/tests/RPM/Tags_TagSpec.hs
@@ -1,0 +1,34 @@
+module RPM.Tags_TagSpec (spec) where
+
+import Test.Hspec
+import RPM.Tags(Null(..),
+                Tag(..))
+
+spec :: Spec
+spec = describe "RPM.Tags data types" $ do
+  describe "Null" $
+    it "is equal to itself" $ do
+      let null_1 = Null
+      null_1 == null_1 `shouldBe` True
+
+-- not implemented
+--    it "is different than non-null" $ do
+--      let null_1 = Null
+--      null_1 /= 1 `shouldBe` True
+
+  describe "Tag" $ do
+    it "is equal to itself" $ do
+      let tag_1 = Name "anaconda"
+      tag_1 == tag_1 `shouldBe` True
+
+    it "tags with two different values are different" $ do
+      let tag_1 = Version "20"
+      let tag_2 = Version "25"
+
+      tag_1 /= tag_2 `shouldBe` True
+
+    it "two different tags are different" $ do
+      let tag_1 = Name "anaconda"
+      let tag_2 = Version "25"
+
+      tag_1 /= tag_2 `shouldBe` True

--- a/tests/RPM/Tags_findSpec.hs
+++ b/tests/RPM/Tags_findSpec.hs
@@ -1,0 +1,163 @@
+module RPM.Tags_findSpec (spec) where
+
+import Test.Hspec
+import RPM.Tags(findTag,
+                findByteStringTag,
+                findStringTag,
+                findStringListTag,
+                findWord16Tag,
+                findWord16ListTag,
+                findWord32Tag,
+                findWord32ListTag,
+                Tag(..))
+import qualified Data.ByteString.Char8 as BC
+
+
+spec :: Spec
+spec = describe "RPM.Tags.find*" $ do
+  describe "findTag" $ do
+    it "returns Nothing if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findTag "NonExistingTag" tags `shouldBe` Nothing
+
+    it "returns Nothing if searching inside empty list" $
+      findTag "ProvideName" [] `shouldBe` Nothing
+
+    it "returns Maybe Tag if name is in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tag_2 = RequireName ["python"]
+      let tag_3 = RequireVersion ["3.5"]
+      let tags = [tag_1, tag_2, tag_3]
+
+      findTag "ProvideName" tags `shouldBe` Just tag_1
+      findTag "RequireName" tags `shouldBe` Just tag_2
+      findTag "RequireVersion" tags `shouldBe` Just tag_3
+
+
+  describe "findByteStringTag" $ do
+    it "returns Nothing if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findByteStringTag "NonExistingTag" tags `shouldBe` Nothing
+
+    it "returns Nothing if searching inside empty list" $
+      findByteStringTag "ProvideName" [] `shouldBe` Nothing
+
+    it "returns Maybe ByteString if name is in the list of tags" $ do
+      let tag_1 = Summary (BC.pack "anaconda")
+      let tag_2 = Description (BC.pack "The installer")
+      let tags = [tag_1, tag_2]
+
+      findByteStringTag "Summary" tags `shouldBe` Just (BC.pack "anaconda")
+      findByteStringTag "Description" tags `shouldBe` Just (BC.pack "The installer")
+
+
+  describe "findStringTag" $ do
+    it "returns Nothing if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findStringTag "NonExistingTag" tags `shouldBe` Nothing
+
+    it "returns Nothing if searching inside empty list" $
+      findStringTag "ProvideName" [] `shouldBe` Nothing
+
+    it "returns Maybe String if name is in the list of tags" $ do
+      let tag_1 = Name "anaconda"
+      let tag_2 = Version "25"
+      let tags = [tag_1, tag_2]
+
+      findStringTag "Name" tags `shouldBe` Just "anaconda"
+      findStringTag "Version" tags `shouldBe` Just "25"
+
+
+  describe "findStringListTag" $ do
+    it "returns [] if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findStringListTag "NonExistingTag" tags `shouldBe` []
+
+    it "returns [] if searching inside empty list" $
+      findStringListTag "ProvideName" [] `shouldBe` []
+
+    it "returns [String] if name is in the list of tags" $ do
+      let tag_1 = ChangeLog ["something", "changed"]
+      let tag_2 = Source ["anaconda.tar.gz"]
+      let tags = [tag_1, tag_2]
+
+      findStringListTag "ChangeLog" tags `shouldBe` ["something", "changed"]
+      findStringListTag "Source" tags `shouldBe` ["anaconda.tar.gz"]
+
+
+  describe "findWord16Tag" $ do
+    it "returns Nothing if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findWord16Tag "NonExistingTag" tags `shouldBe` Nothing
+
+    it "returns Nothing if searching inside empty list" $
+      findWord16Tag "ProvideName" [] `shouldBe` Nothing
+
+    -- "there are no tags holding Word16 values, so no test for those"
+
+
+  describe "findWord16ListTag" $ do
+    it "returns [] if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findWord16ListTag "NonExistingTag" tags `shouldBe` []
+
+    it "returns [] if searching inside empty list" $
+      findWord16ListTag "ProvideName" [] `shouldBe` []
+
+    it "returns [Word16] if name is in the list of tags" $ do
+      let tag_1 = FileModes [5]
+      let tag_2 = FileRDevs [1]
+      let tags = [tag_1, tag_2]
+
+      findWord16ListTag "FileModes" tags `shouldBe` [5]
+      findWord16ListTag "FileRDevs" tags `shouldBe` [1]
+
+
+  describe "findWord32Tag" $ do
+    it "returns Nothing if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findWord32Tag "NonExistingTag" tags `shouldBe` Nothing
+
+    it "returns Nothing if searching inside empty list" $
+      findWord32Tag "ProvideName" [] `shouldBe` Nothing
+
+    it "returns Maybe Word32 if name is in the list of tags" $ do
+      let tag_1 = InstallColor 5
+      let tag_2 = PackageColor 1
+      let tags = [tag_1, tag_2]
+
+      findWord32Tag "InstallColor" tags `shouldBe` Just 5
+      findWord32Tag "PackageColor" tags `shouldBe` Just 1
+
+
+  describe "findWord32ListTag" $ do
+    it "returns [] if name is not in the list of tags" $ do
+      let tag_1 = ProvideName ["anaconda"]
+      let tags = [tag_1]
+
+      findWord32ListTag "NonExistingTag" tags `shouldBe` []
+
+    it "returns [] if searching inside empty list" $
+      findWord32ListTag "ProvideName" [] `shouldBe` []
+
+    it "returns [Word32] if name is in the list of tags" $ do
+      let tag_1 = FileUIDs [1000]
+      let tag_2 = FileGIDs [1001, 1002]
+      let tags = [tag_1, tag_2]
+
+      findWord32ListTag "FileUIDs" tags `shouldBe` [1000]
+      findWord32ListTag "FileGIDs" tags `shouldBe` [1001, 1002]

--- a/tests/RPM/Tags_mkTagSpec.hs
+++ b/tests/RPM/Tags_mkTagSpec.hs
@@ -1,4 +1,4 @@
-module RPM.TagsSpec (spec) where
+module RPM.Tags_mkTagSpec (spec) where
 
 import Test.Hspec
 import Data.Foldable(forM_)
@@ -9,8 +9,7 @@ import qualified Data.ByteString.Char8 as BC
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 
 spec :: Spec
-spec = describe "RPM.Tags" $
-  describe "mkTag" $ do
+spec = describe "RPM.Tags.mkTag" $ do
     it "returns Nothing for unsupported `tag' value" $ do
       let store = BS.pack [0]
       let tag = mkTag store 9999 0 0 0


### PR DESCRIPTION
@clumens the `find*` functions and the `tagValue` function in this module don't appear to be used anywhere else. Do we want to keep them around or can safely delete them? 