### PR TITLE
Add tests for version satisfies without release in reversed order

### DIFF
--- a/tests/RPM/VersionSpec.hs
+++ b/tests/RPM/VersionSpec.hs
@@ -176,6 +176,7 @@ spec = do
               ("thing <= 1.0",   "thing >= 1.0",    True),
               ("thing <= 1.0",   "thing <= 1.0",    True),
 
+              -- test versions without releases
               ("thing <= 1.0",   "thing = 1.0-9",   True),
               ("thing <= 1.0",   "thing < 1.0-9",   True),
               ("thing <= 1.0",   "thing <= 1.0-9",  True),
@@ -187,6 +188,19 @@ spec = do
               ("thing >= 1.0",   "thing <= 1.0-9",  True),
               ("thing >= 1.0",   "thing >= 1.0-9",  True),
               ("thing >= 1.0",   "thing > 1.0-9",   True),
+
+              -- test versions without releases by swapping the order
+              ("thing <= 1.0-8",   "thing = 1.0",   True),
+              ("thing <= 1.0-8",   "thing < 1.0",   True),
+              ("thing <= 1.0-8",   "thing <= 1.0",  True),
+              ("thing <= 1.0-8",   "thing >= 1.0",  True),
+              ("thing <= 1.0-8",   "thing > 1.0",   True),
+
+              ("thing >= 1.0-8",   "thing = 1.0",   True),
+              ("thing >= 1.0-8",   "thing < 1.0",   False),
+              ("thing >= 1.0-8",   "thing <= 1.0",  True),
+              ("thing >= 1.0-8",   "thing >= 1.0",  True),
+              ("thing >= 1.0-8",   "thing > 1.0",   True),
 
               ("thing = 1.0-9",  "thing = 1.0-9",   True),
               ("thing < 1.0-9",  "thing = 1.0-9",   False),


### PR DESCRIPTION
@dashea this PR adds test conditions for the other branch of the condition (line 133) in `satisfiesVersion`, which previously was not tested:

```
  131     satisfiesVersion (Just (o1, v1)) (Just (o2, v2))
  132         | T.null (release v1) && (not . T.null) (release v2) && compareEV v1 v2 && isEq o1 = True
  133         | T.null (release v2) && (not . T.null) (release v1) && compareEV v1 v2 && isEq o2 = True
```

Currently I get only 1 failure, all of the other pairs PASS:

```
  tests/RPM/VersionSpec.hs:299: 
  1) RPM.Version.RPM.Version.satisfies thing >= 1.0-8 thing < 1.0: True
       expected: True
        but got: False
```

Not sure if a bug or my pair is invalid for this test. 


