### PR TITLE
Parser tests & more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 script:
   - ~/.cabal/bin/hlint .
   - cabal install --dependencies-only --enable-tests
-  - cabal configure --enable-tests --enable-coverage --enable-library-coverage
+  - cabal configure --enable-tests --enable-coverage --ghc-option=-DTEST
   - cabal build
   - cabal test --show-details=always
 

--- a/RPM/Parse.hs
+++ b/RPM/Parse.hs
@@ -17,7 +17,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-module RPM.Parse(parseRPM,
+module RPM.Parse(
+#ifdef TEST
+                 parseLead,
+                 parseSectionHeader,
+#endif
+                 parseRPM,
                  parseRPMC)
  where
 

--- a/rpm.cabal
+++ b/rpm.cabal
@@ -105,8 +105,10 @@ test-suite tests
     
     build-depends:      HUnit,
                         hspec,
+                        hspec-attoparsec,
                         base >= 4.7 && < 5.0,
                         bytestring,
+                        attoparsec,
                         rpm,
                         text
 

--- a/tests/RPM/ParseSpec.hs
+++ b/tests/RPM/ParseSpec.hs
@@ -1,0 +1,127 @@
+module RPM.ParseSpec (spec) where
+
+import Test.Hspec
+import Test.Hspec.Attoparsec
+import qualified Data.ByteString as BS
+
+import RPM.Parse
+import RPM.Types(Lead(..), SectionHeader(..))
+
+
+spec :: Spec
+spec = describe "RPM.Parse" $ do
+  describe "parseLead" $ do
+    it "fails with wrong file signature" $ do
+      let stream = BS.pack [
+            0xFF, 0xFF, 0xFF, 0xFF, -- *WRONG* File signature
+            8, -- Major
+            9, -- Minor
+            0, 1, -- Type
+            0, 2,  -- ArchNum
+            65, 66, 67, 68, 69, 70, -- name 66 bytes ABCDEF
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, -- OS num
+            0, 4, -- Sig type
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] -- 16 bytes padding
+      parseLead `shouldFailOn` stream
+      -- NOTE: http://alpmestan.com/posts/2014-06-18-testing-attoparsec-parsers-with-hspec.html
+      -- Right now, hspec-attoparsec will only consider leftovers when the parser succeeds.
+      -- I’m not really sure whether we should return Fail’s unconsumed input or not.
+      --
+      -- We can't use `leavesUnconsumed` when the parser fails
+      -- so the following assertion is invalid for now!
+      -- stream ~?> parseLead `leavesUnconsumed` BS.pack []
+
+    it "fails when name < 66 chars" $ do
+      let stream = BS.pack [
+            0xED, 0xAB, 0xEE, 0xDB, -- File signature
+            8, -- Major
+            9, -- Minor
+            0, 1, -- Type
+            0, 1,  -- ArchNum
+            65, 66, 67, 68, 69, 70, -- name 26 instead of 66 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, -- OS num
+            0, 4, -- Sig type
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] -- 16 bytes padding
+
+      parseLead `shouldFailOn` stream
+
+    it "fails when padding < 16 bytes" $ do
+      let stream = BS.pack [
+            0xED, 0xAB, 0xEE, 0xDB, -- File signature
+            8, -- Major
+            9, -- Minor
+            0, 1, -- Type
+            0, 1,  -- ArchNum
+            65, 66, 67, 68, 69, 70, -- name 66 bytes
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, -- OS num
+            0, 4, -- Sig type
+            0, 0, 0, 0, 0, 0] -- 6 instead of 16 bytes padding
+
+      parseLead `shouldFailOn` stream
+
+    it "succeeds with valid data" $ do
+      let stream = BS.pack [
+            0xED, 0xAB, 0xEE, 0xDB, -- File signature
+            8, -- Major
+            9, -- Minor
+            0, 1, -- Type
+            0, 2,  -- ArchNum
+            65, 66, 67, 68, 69, 70, -- name 66 bytes ABCDEF
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, -- OS num
+            0, 4, -- Sig type
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] -- 16 bytes padding
+      let expected = Lead 8 9 1 2 "ABCDEF" 1 4
+
+      -- parsing succeeds
+      parseLead `shouldSucceedOn` stream
+      -- no unconsumed input
+      stream ~?> parseLead `leavesUnconsumed` BS.pack []
+      -- result is as expected
+      stream ~> parseLead `parseSatisfies` (==expected)
+
+  describe "parseSectionHeader" $ do
+    it "fails with invalid section header signature" $ do
+      let stream = BS.pack [
+            0xFF, 0xFF, 0xFF, -- *WRONG* section header signature
+            8, -- sectionVersion
+            0, 0, 0, 0, -- 4 reserved bytes
+            255, 255, 255, 255, -- sectionCount 4 bytes
+            0, 0, 255, 255] -- sectionSize 4 bytes
+
+      parseSectionHeader `shouldFailOn` stream
+
+    it "fails when reserved section < 4 bytes" $ do
+      let stream = BS.pack [
+            0x8E, 0xAD, 0xE8, -- section header signature
+            8, -- sectionVersion
+            0, 0, -- *2 instead of* 4 reserved bytes
+            255, 255, 255, 255, -- sectionCount 4 bytes
+            0, 0, 255, 255] -- sectionSize 4 bytes
+
+      parseSectionHeader `shouldFailOn` stream
+
+    it "succeeds with valid data" $ do
+      let stream = BS.pack [
+            0x8E, 0xAD, 0xE8, -- section header signature
+            8, -- sectionVersion
+            0, 0, 0, 0, -- 4 reserved bytes
+            255, 255, 255, 255, -- sectionCount 4 bytes
+            0, 0, 255, 255] -- sectionSize 4 bytes
+      let expected = SectionHeader 8 4294967295 65535
+
+      -- parsing succeeds
+      parseSectionHeader `shouldSucceedOn` stream
+      -- no unconsumed input
+      stream ~?> parseSectionHeader `leavesUnconsumed` BS.pack []
+      -- result is as expected
+      stream ~> parseSectionHeader `parseSatisfies` (==expected)

--- a/tests/RPM/TypesSpec.hs
+++ b/tests/RPM/TypesSpec.hs
@@ -1,0 +1,16 @@
+module RPM.TypesSpec (spec) where
+
+import Test.Hspec
+import RPM.Types(SectionHeader(..))
+
+spec :: Spec
+spec = describe "RPM.Types" $
+  describe "SectionHeader" $ do
+    it "is equal to itself" $ do
+      let header_1 = SectionHeader 0 1 1
+      header_1 == header_1 `shouldBe` True
+
+    it "is not equal to another" $ do
+      let header_1 = SectionHeader 0 1 1
+      let header_2 = SectionHeader 1 1 1
+      header_1 /= header_2 `shouldBe` True


### PR DESCRIPTION
ATM I get the following compilation error:

```
tests/RPM/ParseSpec.hs:28:7: error:
    • No instance for (Eq (Result Lead))
        arising from a use of ‘shouldBe’
    • In a stmt of a 'do' block:
        parse parseLead store `shouldBe` Done (BS.pack []) lead
      In the second argument of ‘($)’, namely
        ‘do { let store = BS.pack ...;
              let lead = Lead 0 0 1 1 "aaa" 1 4;
              parse parseLead store `shouldBe` Done (BS.pack []) lead }’
      In the second argument of ‘($)’, namely
        ‘it "returns Lead from valid data"
         $ do { let store = BS.pack ...;
                let lead = Lead 0 0 1 1 "aaa" 1 4;
                parse parseLead store `shouldBe` Done (BS.pack []) lead }’
```
