### PR TITLE
Throw error if input stream length is less than expected

### DIFF
--- a/RPM/Tags.hs
+++ b/RPM/Tags.hs
@@ -682,52 +682,60 @@ mkNull _ ty _ _ | ty == 0    = Just Null
                 | otherwise  = Nothing
 
 mkChar :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe [Char]
-mkChar store ty offset count | ty == 1   = Just $ C.unpack $ BS.take count' start
+mkChar store ty offset count | fromIntegral (BS.length store) - offset < count = Nothing
+                             | ty == 1   = Just $ C.unpack $ BS.take count' start
                              | otherwise = Nothing
  where
     count' = fromIntegral count
     start = BS.drop (fromIntegral offset) store
 
 mkWord16 :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe [Word16]
-mkWord16 store ty offset count | ty == 3     = Just $ readWords store 2 asWord16 offsets
+mkWord16 store ty offset count | fromIntegral (BS.length store) - offset < (2*count) = Nothing
+                               | ty == 3     = Just $ readWords store 2 asWord16 offsets
                                | otherwise   = Nothing
  where
     offsets = map (\n -> offset + (n*2)) [0 .. count-1]
 
 mkWord32 :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe [Word32]
-mkWord32 store ty offset count | ty == 4     = Just $ readWords store 4 asWord32 offsets
+mkWord32 store ty offset count | fromIntegral (BS.length store) - offset < (4*count) = Nothing
+                               | ty == 4     = Just $ readWords store 4 asWord32 offsets
                                | otherwise   = Nothing
  where
     offsets = map (\n -> offset + (n*4)) [0 .. count-1]
 
 mkWord64 :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe [Word64]
-mkWord64 store ty offset count | ty == 5     = Just $ readWords store 8 asWord64 offsets
+mkWord64 store ty offset count | fromIntegral (BS.length store) - offset < (8*count) = Nothing
+                               | ty == 5     = Just $ readWords store 8 asWord64 offsets
                                | otherwise   = Nothing
  where
     offsets = map (\n -> offset + (n*8)) [0 .. count-1]
 
 mkString :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe String
-mkString store ty offset _ | ty == 6   = Just $ C.unpack $ BS.takeWhile (/= 0) start
-                           | otherwise = Nothing
+mkString store ty offset count | fromIntegral (BS.length store) - offset < count = Nothing
+                               | ty == 6   = Just $ C.unpack $ BS.takeWhile (/= 0) start
+                               | otherwise = Nothing
  where
     start = BS.drop (fromIntegral offset) store
 
 mkBinary :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe BS.ByteString
-mkBinary store ty offset count | ty == 7     = Just $ BS.take count' start
+mkBinary store ty offset count | fromIntegral (BS.length store) - offset < count = Nothing
+                               | ty == 7     = Just $ BS.take count' start
                                | otherwise   = Nothing
  where
     count' = fromIntegral count
     start  = BS.drop (fromIntegral offset) store
 
 mkStringArray :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe [String]
-mkStringArray store ty offset count | ty == 8    = Just $ map C.unpack $ readStrings start count
+mkStringArray store ty offset count | fromIntegral (BS.length store) - offset < count = Nothing
+                                    | ty == 8    = Just $ map C.unpack $ readStrings start count
                                     | otherwise  = Nothing
  where
     start = BS.drop (fromIntegral offset) store
 
 mkI18NString :: BS.ByteString -> Word32 -> Word32 -> Word32 -> Maybe BS.ByteString
-mkI18NString store ty offset _ | ty == 9     = Just $ BS.takeWhile (/= 0) start
-                               | otherwise   = Nothing
+mkI18NString store ty offset count | fromIntegral (BS.length store) - offset < count = Nothing
+                                   | ty == 9     = Just $ BS.takeWhile (/= 0) start
+                                   | otherwise   = Nothing
  where
     start  = BS.drop (fromIntegral offset) store
 

--- a/tests/RPM/Tags_mkTagSpec.hs
+++ b/tests/RPM/Tags_mkTagSpec.hs
@@ -116,8 +116,8 @@ spec = describe "RPM.Tags.mkTag" $ do
             5068, 5070, 5072, 5078, 5080, 5082, 5084, 5085,
             5091] $ \tagInt -> do
       it ("returns Nothing for `tag' == " ++ show tagInt ++ " and `ty' != 4") $ do
-        let store = BS.pack [0]
-        let tag = mkTag store tagInt 99 0 0
+        let store = BS.pack [0, 0, 0, 5]
+        let tag = mkTag store tagInt 99 0 1
         tag `shouldBe` Nothing
 
       it ("returns correct value for `tag' == " ++ show tagInt) $ do
@@ -691,3 +691,17 @@ spec = describe "RPM.Tags.mkTag" $ do
             tag == Just (Description store) || -- 1005
             tag == Just (Group store) -- 1016
             `shouldBe` True
+
+    it "mkTag returns Nothing when store is empty" $ do
+      mkTag (BC.pack "") 1029 1 0 1 `shouldBe` Nothing -- mkChar
+      mkTag (BC.pack []) 1030 3 0 1 `shouldBe` Nothing -- mkWord16
+      mkTag (BS.pack []) 1003 4 0 1 `shouldBe` Nothing -- mkWord32
+      mkTag (BS.pack [])  270 5 0 1 `shouldBe` Nothing -- mkWord64
+      mkTag (BS.pack [])  259 7 0 1 `shouldBe` Nothing -- mkBinary
+      mkTag (BC.pack "")  100 8 0 1 `shouldBe` Nothing -- mkStringArray
+      mkTag (BC.pack "") 1000 6 0 7 `shouldBe` Nothing -- mkString
+      mkTag (BC.pack "") 1004 9 0 7 `shouldBe` Nothing -- mkI18NString
+
+    it "mkTag -> mkNull returns valid data even when store is empty" $
+      -- because mkNull doesn't read from the store
+      mkTag (BS.pack []) 61 0 0 1 `shouldBe` Just (HeaderImage Null)


### PR DESCRIPTION
If the input byte-stream is shorter than what we want to read then throw error and add tests for that.

Note: mkNull, mkString and mkI18NString don't implement these checks at the moment

@dashea please review and also let me know if we want to implement this type of error checking for mkNull, mkString and mkI18NString ?